### PR TITLE
Fix chain velocity formula

### DIFF
--- a/06-virtues/06-virtues.tex
+++ b/06-virtues/06-virtues.tex
@@ -480,7 +480,7 @@ chain of an honest party grows over a period of time is the chain velocity.
 \begin{definition}[Chain Velocity]
   Consider an honest party and his chain $C_1$, $C_2$ at times $r_1 < r_2$ respectively.
   We say the chain has grown with a \emph{velocity}
-  $\tau = \frac{|C_2| - |C_1|}{|\chain_{r_2}| - |\chain_{r_1}|}$
+  $\tau = \frac{|C_2| - |C_1|}{r_2 - r_1}$
   between those times.
 \end{definition}
 


### PR DESCRIPTION
Denominator should be the difference between times/rounds, not the same difference between chain lengths that is the numerator.