### PR TITLE
Fix typo: "mines" --> "miners"

### DIFF
--- a/08-economics/08-economics.tex
+++ b/08-economics/08-economics.tex
@@ -575,7 +575,7 @@ Honest mining power $n - t$ can also fluctuate. In our calculations for the targ
 we have assumed that all the system parameters, including $n$ and $t$ remain
 constant. In reality, however, mining power wildly fluctuates. As a blockchain
 system becomes more popular and the price of its token increases,
-more rational mines join the system hoping to make profit from it. This functions
+more rational miners join the system hoping to make profit from it. This functions
 as a reinforcement mechanism for its security: The more value a system stores,
 the more miners tend to want to mine for it because it is more profitable, and
 the more expensive it becomes to attack, because the adversary needs to


### PR DESCRIPTION
Fix minor typo in section 8.6: "mines" --> "miners"